### PR TITLE
Google trend API 429 workaround

### DIFF
--- a/pipes/pytrends-api-search-clean/src/main.py
+++ b/pipes/pytrends-api-search-clean/src/main.py
@@ -6,7 +6,6 @@ from typing import List
 import pendulum
 from pytz import timezone
 import time
-from requests.exceptions import HTTPError
 
 swedish_tz = timezone('Europe/Stockholm')
 


### PR DESCRIPTION
Add a timeout and some minor tweaks to make the workflow keep trying to fetch data in order to avoid 429 errors.